### PR TITLE
Release 0.2.0: MSRV 1.85, const accessors, new combinators, bug fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
-          - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -79,7 +77,6 @@ jobs:
           - x86_64-pc-windows-gnu
           - i686-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
-          # - mips64-unknown-linux-gnuabi64
           - riscv64gc-unknown-linux-gnu
           - wasm32-unknown-unknown
           - wasm32-unknown-emscripten
@@ -88,9 +85,9 @@ jobs:
           - wasm32-wasip2
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Cache cargo build and registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -104,7 +101,7 @@ jobs:
       - name: cargo build --target ${{ matrix.target }}
         run: |
           rustup target add ${{ matrix.target }}
-          cargo build --target ${{ matrix.target }} 
+          cargo build --target ${{ matrix.target }}
 
   build:
     name: build
@@ -174,44 +171,38 @@ jobs:
       - name: Run test
         run: cargo hack test --feature-powerset 
 
-  # coverage:
-  #   name: coverage
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - rustfmt
-  #     - clippy
-  #     - build
-  #     - cross
-  #     - test
-  #   steps:
-  #     - uses: actions/checkout@v6
-  #     - name: Install latest nightly
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: nightly
-  #         override: true
-  #     - uses: actions-rs/install@v0.1
-  #       with:
-  #         crate: cargo-tarpaulin
-  #         version: latest
-  #     - name: Cache ~/.cargo
-  #       uses: actions/cache@v5
-  #       with:
-  #         path: ~/.cargo
-  #         key: ${{ runner.os }}-coverage-dotcargo
-  #     - name: Cache cargo build
-  #       uses: actions/cache@v5
-  #       with:
-  #         path: target
-  #         key: ${{ runner.os }}-coverage-cargo-build-target
-  #     - name: Run tarpaulin
-  #       uses: actions-rs/cargo@v1
-  #       with:
-  #         command: tarpaulin
-  #         args: --all-features --run-types tests --run-types doctests --workspace --out xml
-  #     - name: Upload to codecov.io
-  #       uses: codecov/codecov-action@v4
-  #       with:
-  #         token: ${{ secrets.CODECOV_TOKEN }}
-  #         fail_ci_if_error: true
-  #         slug: ${{ github.repository }}
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    needs:
+      - rustfmt
+      - clippy
+      - build
+      - cross
+      - test
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust
+        run: rustup update nightly && rustup default nightly
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+      - name: Cache cargo build and registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-coverage-
+      - name: Run tarpaulin
+        env:
+          RUSTFLAGS: "--cfg tarpaulin"
+        run: cargo tarpaulin --all-features --engine llvm --run-types lib --run-types tests --run-types doctests --workspace --out xml
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ${{ github.repository }}
+          fail_ci_if_error: true

--- a/.github/workflows/loc.yml
+++ b/.github/workflows/loc.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           tokeit
       - name: Upload total loc to GitHub Gist
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GIST_PAT }}
           script: |

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 /target
 Cargo.lock
+**.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
-# 0.2.0 (Unreleased)
+# 0.2.0 (Apr 23rd, 2026)
+
+BREAKING
+
+- Bump minimum supported Rust version (MSRV) to 1.85.0.
+
+FEATURES
+
+- Make the following borrowing accessors `const fn`: `is_left`, `is_middle`, `is_right`, `as_ref`, `as_mut`, `as_pin_ref`, `as_pin_mut`, `left_ref`, `middle_ref`, `right_ref`, `left_mut`, `middle_mut`, `right_mut`, `Among::<T, T, T>::as_inner` and `Among::<T, T, T>::as_inner_mut`.
+- Make `Among::<&L, &M, &R>::copied` and `Among::<&mut L, &mut M, &mut R>::copied` `const fn`.
+
+- Add `Among::is_left_and`, `Among::is_middle_and` and `Among::is_right_and` for predicate-aware variant checks.
+- Add `Among::inspect_left`, `Among::inspect_middle` and `Among::inspect_right` for side-effectful observation that passes `self` through.
+- Add `Among::left_ref`, `Among::middle_ref`, `Among::right_ref`, `Among::left_mut`, `Among::middle_mut` and `Among::right_mut` as `Option<&_>` / `Option<&mut _>` shortcuts over `as_ref()` / `as_mut()`.
+- Add `Among::insert_left`, `Among::insert_middle` and `Among::insert_right` to overwrite `self` with the named variant and return a mutable reference to the new value.
+- Add `Among::get_or_insert_left`, `Among::get_or_insert_middle`, `Among::get_or_insert_right` and their lazy `*_with` counterparts.
+- Add `Among::try_among_into::<T>` for fallible conversion, preserving the originating side via `Result<T, Among<E_L, E_M, E_R>>`.
+- Add `Among::as_inner` and `Among::as_inner_mut` on `Among<T, T, T>` to borrow the contained value without consuming it.
 
 BUG FIXES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,77 @@
-# UNRELEASED
+# 0.2.0 (Unreleased)
+
+BUG FIXES
+
+- Fix `Among::unwrap_left` panic message to reference `unwrap_left` instead of `unwrap_middle` when invoked on a `Middle` value.
+- Fix `Among::unwrap_right` panic message to reference `unwrap_right` instead of `unwrap_middle` when invoked on a `Middle` value.
+- Add the missing `(Middle, Middle)` in-place branch to `Clone::clone_from`, so the `Middle` variant reuses its allocation like `Left` and `Right` already do.
+
+DOCS
+
+- Fix `Among::is_middle` doc comment that incorrectly described the `Right` variant.
+- Expand the `# Panics` sections on `unwrap_left`, `unwrap_middle` and `unwrap_right` to list both panicking variants.
+- Add `# Panics` sections to `Among::into_left_middle`, `Among::into_middle_right` and `Among::into_left_right`.
+- Drop stray semicolons after the `struct` definitions in the `serde_untagged` and `serde_untagged_optional` module-level doctests.
+
+TESTS
+
+- Remove the unused `mockvec` write inside the `seek` test's mock-data loop.
+
+# 0.1.8 (Jan 24th, 2026)
+
+FEATURES
+
+- Add `Among::flip_left_middle` and `Among::flip_middle_right` to swap adjacent variants without permuting all three type parameters.
+- Add `Among::shift_left` and `Among::shift_right` to rotate the variant in a single direction ([#7](https://github.com/al8n/among/issues/7), [#9](https://github.com/al8n/among/pull/9)).
+
+# 0.1.7 (Oct 14th, 2024)
+
+FEATURES
+
+- Add `Among::try_into_left_middle`, `Among::try_into_middle_right`, `Among::try_into_left_right` and their panicking `into_*` counterparts, gated behind the `either` feature.
+- Add `Among::from_either_to_left_right`, `Among::from_either_to_left_middle` and `Among::from_either_to_middle_right`.
+
+# 0.1.6 (Oct 8th, 2024)
+
+FIXES
+
+- Fix `cargo doc` generation (feature gating / `docs.rs` metadata).
+
+# 0.1.5 (Oct 7th, 2024)
+
+FEATURES
+
+- Add `AmongErrorExt` / `AmongOkExt` extension traits for `Result<_, Among<_,_,_>>` and `Result<Among<_,_,_>, _>` with `map_err_{left,middle,right}` and `map_{left,middle,right}` helpers.
+- Add `EitherOkExt` / `EitherErrExt` extension traits mirroring the above for `Result<_, Either<_, _>>` and `Result<Either<_, _>, _>`.
+
+# 0.1.4 (Oct 7th, 2024)
+
+CHANGES
+
+- Adjust the `From<Either<A, B>>` blanket impls for `Among` so the three-way conversions compose more ergonomically.
+
+# 0.1.3 (Oct 4th, 2024)
+
+FEATURES
+
+- Additional `either` conversion helpers on top of the 0.1.2 surface.
+
+# 0.1.2 (Sep 14th, 2024)
+
+FEATURES
+
+- Add the `either` feature, introducing `src/either_impl.rs` with the initial `Either` ↔ `Among` conversion API.
+
+# 0.1.1 (Sep 3rd, 2024)
+
+CHANGES
+
+- Reorganise the crate manifest and CI workflow; publish to crates.io.
 
 # 0.1.0 (Sep 3rd, 2024)
 
 FEATURES
+
+- Initial release: the `Among<L, M, R>` sum type with `Left`/`Middle`/`Right` variants and trait impls (`Clone`, `Copy`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Hash`, `Debug`, `Display`, `Error`, `Future`, `Iterator`/`DoubleEndedIterator`/`ExactSizeIterator`/`FusedIterator`, `Read`/`Write`/`Seek`/`BufRead`, `AsRef`/`AsMut`, `Deref`/`DerefMut`, `Extend`).
+- Optional `serde` (`serde_untagged`, `serde_untagged_optional`), `futures` (`AsyncRead`/`AsyncBufRead`/`AsyncWrite`/`AsyncSeek`) and `tokio` (`AsyncRead`/`AsyncBufRead`/`AsyncWrite`/`AsyncSeek`) integrations.
+- `IntoAmong` trait and `IterAmong` iterator adaptor.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "among"
 version = "0.2.0"
 edition = "2018"
-rust-version = "1.37"
+rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/al8n/among"
 homepage = "https://github.com/al8n/among"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,16 @@
 [package]
 name = "among"
-version = "0.1.8"
+version = "0.2.0"
 edition = "2018"
 rust-version = "1.37"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/al8n/among"
 homepage = "https://github.com/al8n/among"
 documentation = "https://docs.rs/among"
-description = """
-The enum `Among` with variants `Left`, `Middle` and `Right` is a general purpose sum type with three cases.
-"""
+description = "A general purpose sum type with three cases: the enum `Among` with variants `Left`, `Middle` and `Right`. A three-way counterpart to `Either`, with `no_std`, `serde`, `futures` and `tokio` integrations."
 
-keywords = ["data-structure", "no_std", "either"]
-categories = ["data-structures", "no-std"]
+keywords = ["data-structure", "no-std", "either", "sum-type", "enum"]
+categories = ["data-structures", "no-std", "rust-patterns"]
 
 [features]
 default = ["std"]

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright [2026] [Al Liu]
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2015 The Rust Project Developers
+Copyright (c) 2026 Al Liu
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The enum `Among` with variants `Left`, `Middle` and `Right` is a general purpose
 [<img alt="github" src="https://img.shields.io/badge/github-al8n/among-8da0cb?style=for-the-badge&logo=Github" height="22">][Github-url]
 <img alt="LoC" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fal8n%2F327b2a8aef9003246e45c6e47fe63937%2Fraw%2Famong" height="22">
 [<img alt="Build" src="https://img.shields.io/github/actions/workflow/status/al8n/among/ci.yml?logo=Github-Actions&style=for-the-badge" height="22">][CI-url]
-<!-- [<img alt="codecov" src="https://img.shields.io/codecov/c/gh/al8n/among?style=for-the-badge&token=6R3QFWRWHL&logo=codecov" height="22">][codecov-url] -->
+[<img alt="codecov" src="https://img.shields.io/codecov/c/gh/al8n/among?style=for-the-badge&token=6R3QFWRWHL&logo=codecov" height="22">][codecov-url]
 
 [<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-among-66c2a5?style=for-the-badge&labelColor=555555&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K" height="20">][doc-url]
 [<img alt="crates.io" src="https://img.shields.io/crates/v/among?style=for-the-badge&logo=data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iaXNvLTg4NTktMSI/Pg0KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE5LjAuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPg0KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCINCgkgdmlld0JveD0iMCAwIDUxMiA1MTIiIHhtbDpzcGFjZT0icHJlc2VydmUiPg0KPGc+DQoJPGc+DQoJCTxwYXRoIGQ9Ik0yNTYsMEwzMS41MjgsMTEyLjIzNnYyODcuNTI4TDI1Niw1MTJsMjI0LjQ3Mi0xMTIuMjM2VjExMi4yMzZMMjU2LDB6IE0yMzQuMjc3LDQ1Mi41NjRMNzQuOTc0LDM3Mi45MTNWMTYwLjgxDQoJCQlsMTU5LjMwMyw3OS42NTFWNDUyLjU2NHogTTEwMS44MjYsMTI1LjY2MkwyNTYsNDguNTc2bDE1NC4xNzQsNzcuMDg3TDI1NiwyMDIuNzQ5TDEwMS44MjYsMTI1LjY2MnogTTQzNy4wMjYsMzcyLjkxMw0KCQkJbC0xNTkuMzAzLDc5LjY1MVYyNDAuNDYxbDE1OS4zMDMtNzkuNjUxVjM3Mi45MTN6IiBmaWxsPSIjRkZGIi8+DQoJPC9nPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPGc+DQo8L2c+DQo8Zz4NCjwvZz4NCjxnPg0KPC9nPg0KPC9zdmc+DQo=" height="22">][crates-url]
@@ -64,7 +64,7 @@ Apache License (Version 2.0).
 
 See [LICENSE-APACHE](LICENSE-APACHE), [LICENSE-MIT](LICENSE-MIT) for details.
 
-Copyright (c) 2024 Al Liu.
+Copyright (c) 2026 Al Liu.
 
 [Github-url]: https://github.com/al8n/among/
 [CI-url]: https://github.com/al8n/among/actions/workflows/ci.yml

--- a/README.md
+++ b/README.md
@@ -29,28 +29,28 @@ The enum `Among` with variants `Left`, `Middle` and `Right` and trait implementa
   
   ```toml
   [dependencies]
-  among = "0.1"
+  among = "0.2"
   ```
 
 - Use without `std` and `alloc`
 
   ```toml
   [dependencies]
-  among = { version = "0.1", default-features = false }
+  among = { version = "0.2", default-features = false }
   ```
 
 - Enable `futures` feature to enable trait implementation including `futures::io::AsyncRead`, `futures::io::AsyncBufRead`, `futures::io::AsyncWrite`, and `futures::io::AsyncSeek`.
   
   ```toml
   [dependencies]
-  among = { version = "0.1", features = ["futures", "std"] }
+  among = { version = "0.2", features = ["futures", "std"] }
   ```
 
 - Enable `tokio` feature to enable trait implementation including `tokio::io::AsyncRead`, `tokio::io::AsyncBufRead`, `tokio::io::AsyncWrite` and `tokio::io::AsyncSeek`.
 
   ```toml
   [dependencies]
-  among = { version = "0.1", features = ["tokio", "std"] }
+  among = { version = "0.2", features = ["tokio", "std"] }
   ```
 
 ## Pedigree

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,6 +3,7 @@ hard_tabs = false
 tab_spaces = 2
 newline_style = "Auto"
 use_small_heuristics = "Default"
+imports_granularity = "Crate"
 reorder_imports = true
 reorder_modules = true
 remove_nested_parens = true

--- a/src/either_impl.rs
+++ b/src/either_impl.rs
@@ -54,6 +54,10 @@ impl<L, M, R> Among<L, M, R> {
   ///
   /// assert_eq!(either, Either::Right(2));
   /// ```
+  ///
+  /// # Panics
+  ///
+  /// Panics if `self` is `Among::Right`.
   #[inline]
   pub fn into_left_middle(self) -> Either<L, M> {
     match self {
@@ -114,6 +118,10 @@ impl<L, M, R> Among<L, M, R> {
   ///
   /// assert_eq!(either, Either::Right(3));
   /// ```
+  ///
+  /// # Panics
+  ///
+  /// Panics if `self` is `Among::Left`.
   #[inline]
   pub fn into_middle_right(self) -> Either<M, R> {
     match self {
@@ -177,6 +185,10 @@ impl<L, M, R> Among<L, M, R> {
   /// assert_eq!(either, Either::Right(3));
   ///
   /// ```
+  ///
+  /// # Panics
+  ///
+  /// Panics if `self` is `Among::Middle`.
   #[inline]
   pub fn into_left_right(self) -> Either<L, R> {
     match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ impl<L: Clone, M: Clone, R: Clone> Clone for Among<L, M, R> {
   fn clone_from(&mut self, source: &Self) {
     match (self, source) {
       (Left(dest), Left(source)) => dest.clone_from(source),
+      (Middle(dest), Middle(source)) => dest.clone_from(source),
       (Right(dest), Right(source)) => dest.clone_from(source),
       (dest, source) => *dest = source.clone(),
     }
@@ -167,7 +168,7 @@ impl<L, M, R> Among<L, M, R> {
     }
   }
 
-  /// Return true if the value is the `Right` variant.
+  /// Return true if the value is the `Middle` variant.
   ///
   /// ```
   /// use among::*;
@@ -1102,7 +1103,7 @@ impl<L, M, R> Among<L, M, R> {
   ///
   /// # Panics
   ///
-  /// When `Among` is a `Right` value
+  /// When `Among` is a `Middle` or `Right` value
   ///
   /// ```should_panic
   /// # use among::*;
@@ -1123,10 +1124,7 @@ impl<L, M, R> Among<L, M, R> {
     match self {
       Among::Left(l) => l,
       Among::Middle(m) => {
-        panic!(
-          "called `Among::unwrap_middle()` on a `Middle` value: {:?}",
-          m
-        )
+        panic!("called `Among::unwrap_left()` on a `Middle` value: {:?}", m)
       }
       Among::Right(r) => {
         panic!("called `Among::unwrap_left()` on a `Right` value: {:?}", r)
@@ -1146,7 +1144,7 @@ impl<L, M, R> Among<L, M, R> {
   ///
   /// # Panics
   ///
-  /// When `Among` is a `Right` value
+  /// When `Among` is a `Left` or `Right` value
   ///
   /// ```should_panic
   /// # use among::*;
@@ -1190,7 +1188,7 @@ impl<L, M, R> Among<L, M, R> {
   ///
   /// # Panics
   ///
-  /// When `Among` is a `Left` value
+  /// When `Among` is a `Left` or `Middle` value
   ///
   /// ```should_panic
   /// # use among::*;
@@ -1210,10 +1208,9 @@ impl<L, M, R> Among<L, M, R> {
   {
     match self {
       Among::Right(r) => r,
-      Among::Middle(m) => panic!(
-        "called `Among::unwrap_middle()` on a `Middle` value: {:?}",
-        m
-      ),
+      Among::Middle(m) => {
+        panic!("called `Among::unwrap_right()` on a `Middle` value: {:?}", m)
+      }
       Among::Left(l) => panic!("called `Among::unwrap_right()` on a `Left` value: {:?}", l),
     }
   }
@@ -1956,11 +1953,10 @@ fn seek() {
 
   let use_empty = 1;
   let mut mockdata = [0x00; 256];
-  let mut mockvec = vec![];
   for (i, elem) in mockdata.iter_mut().enumerate() {
-    mockvec.push(i as u8);
     *elem = i as u8;
   }
+  let mockvec: vec::Vec<u8> = vec![];
 
   let mut reader = if use_empty == 0 {
     // Empty didn't impl Seek until Rust 1.51

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,13 @@ mod tokio_impl;
 mod result_ext;
 pub use result_ext::*;
 
-use core::convert::{AsMut, AsRef};
-use core::fmt;
-use core::future::Future;
-use core::ops::Deref;
-use core::ops::DerefMut;
-use core::pin::Pin;
+use core::{
+  convert::{AsMut, AsRef, TryInto},
+  fmt,
+  future::Future,
+  ops::{Deref, DerefMut},
+  pin::Pin,
+};
 
 #[cfg(any(test, feature = "std"))]
 use std::error::Error;
@@ -144,11 +145,8 @@ impl<L, M, R> Among<L, M, R> {
   /// assert_eq!(values[1].is_left(), false);
   /// assert_eq!(values[2].is_left(), false);
   /// ```
-  pub fn is_left(&self) -> bool {
-    match *self {
-      Left(_) => true,
-      _ => false,
-    }
+  pub const fn is_left(&self) -> bool {
+    matches!(*self, Left(_))
   }
 
   /// Return true if the value is the `Right` variant.
@@ -161,11 +159,8 @@ impl<L, M, R> Among<L, M, R> {
   /// assert_eq!(values[1].is_right(), false);
   /// assert_eq!(values[2].is_right(), true);
   /// ```
-  pub fn is_right(&self) -> bool {
-    match *self {
-      Right(_) => true,
-      _ => false,
-    }
+  pub const fn is_right(&self) -> bool {
+    matches!(*self, Right(_))
   }
 
   /// Return true if the value is the `Middle` variant.
@@ -178,10 +173,187 @@ impl<L, M, R> Among<L, M, R> {
   /// assert_eq!(values[1].is_middle(), true);
   /// assert_eq!(values[2].is_middle(), false);
   /// ```
-  pub fn is_middle(&self) -> bool {
-    match *self {
-      Middle(_) => true,
+  pub const fn is_middle(&self) -> bool {
+    matches!(*self, Middle(_))
+  }
+
+  /// Returns `true` if the value is a `Left` variant and the contained
+  /// value matches the predicate.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let left: Among<u32, u32, u32> = Left(2);
+  /// assert!(left.is_left_and(|x| *x == 2));
+  /// assert!(!left.is_left_and(|x| *x == 3));
+  ///
+  /// let middle: Among<u32, u32, u32> = Middle(2);
+  /// assert!(!middle.is_left_and(|_| true));
+  /// ```
+  pub fn is_left_and<F>(&self, f: F) -> bool
+  where
+    F: FnOnce(&L) -> bool,
+  {
+    match self {
+      Left(l) => f(l),
       _ => false,
+    }
+  }
+
+  /// Returns `true` if the value is a `Middle` variant and the contained
+  /// value matches the predicate.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let middle: Among<u32, u32, u32> = Middle(2);
+  /// assert!(middle.is_middle_and(|x| *x == 2));
+  /// assert!(!middle.is_middle_and(|x| *x == 3));
+  ///
+  /// let left: Among<u32, u32, u32> = Left(2);
+  /// assert!(!left.is_middle_and(|_| true));
+  /// ```
+  pub fn is_middle_and<F>(&self, f: F) -> bool
+  where
+    F: FnOnce(&M) -> bool,
+  {
+    match self {
+      Middle(m) => f(m),
+      _ => false,
+    }
+  }
+
+  /// Returns `true` if the value is a `Right` variant and the contained
+  /// value matches the predicate.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let right: Among<u32, u32, u32> = Right(2);
+  /// assert!(right.is_right_and(|x| *x == 2));
+  /// assert!(!right.is_right_and(|x| *x == 3));
+  ///
+  /// let left: Among<u32, u32, u32> = Left(2);
+  /// assert!(!left.is_right_and(|_| true));
+  /// ```
+  pub fn is_right_and<F>(&self, f: F) -> bool
+  where
+    F: FnOnce(&R) -> bool,
+  {
+    match self {
+      Right(r) => f(r),
+      _ => false,
+    }
+  }
+
+  /// Borrow the `Left` variant as `Option<&L>`; a shorthand for `self.as_ref().left()`.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let left: Among<u32, (), ()> = Left(1);
+  /// assert_eq!(left.left_ref(), Some(&1));
+  ///
+  /// let middle: Among<u32, u32, ()> = Middle(2);
+  /// assert_eq!(middle.left_ref(), None);
+  /// ```
+  pub const fn left_ref(&self) -> Option<&L> {
+    match self {
+      Left(l) => Some(l),
+      _ => None,
+    }
+  }
+
+  /// Borrow the `Middle` variant as `Option<&M>`; a shorthand for `self.as_ref().middle()`.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let middle: Among<(), u32, ()> = Middle(2);
+  /// assert_eq!(middle.middle_ref(), Some(&2));
+  ///
+  /// let left: Among<u32, u32, ()> = Left(1);
+  /// assert_eq!(left.middle_ref(), None);
+  /// ```
+  pub const fn middle_ref(&self) -> Option<&M> {
+    match self {
+      Middle(m) => Some(m),
+      _ => None,
+    }
+  }
+
+  /// Borrow the `Right` variant as `Option<&R>`; a shorthand for `self.as_ref().right()`.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let right: Among<(), (), u32> = Right(3);
+  /// assert_eq!(right.right_ref(), Some(&3));
+  ///
+  /// let left: Among<u32, (), u32> = Left(1);
+  /// assert_eq!(left.right_ref(), None);
+  /// ```
+  pub const fn right_ref(&self) -> Option<&R> {
+    match self {
+      Right(r) => Some(r),
+      _ => None,
+    }
+  }
+
+  /// Mutably borrow the `Left` variant as `Option<&mut L>`.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut left: Among<u32, (), ()> = Left(1);
+  /// if let Some(l) = left.left_mut() { *l = 10; }
+  /// assert_eq!(left, Left(10));
+  ///
+  /// let mut middle: Among<u32, u32, ()> = Middle(2);
+  /// assert!(middle.left_mut().is_none());
+  /// ```
+  pub const fn left_mut(&mut self) -> Option<&mut L> {
+    match self {
+      Left(l) => Some(l),
+      _ => None,
+    }
+  }
+
+  /// Mutably borrow the `Middle` variant as `Option<&mut M>`.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut middle: Among<(), u32, ()> = Middle(2);
+  /// if let Some(m) = middle.middle_mut() { *m = 20; }
+  /// assert_eq!(middle, Middle(20));
+  ///
+  /// let mut left: Among<u32, u32, ()> = Left(1);
+  /// assert!(left.middle_mut().is_none());
+  /// ```
+  pub const fn middle_mut(&mut self) -> Option<&mut M> {
+    match self {
+      Middle(m) => Some(m),
+      _ => None,
+    }
+  }
+
+  /// Mutably borrow the `Right` variant as `Option<&mut R>`.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut right: Among<(), (), u32> = Right(3);
+  /// if let Some(r) = right.right_mut() { *r = 30; }
+  /// assert_eq!(right, Right(30));
+  ///
+  /// let mut left: Among<u32, (), u32> = Left(1);
+  /// assert!(left.right_mut().is_none());
+  /// ```
+  pub const fn right_mut(&mut self) -> Option<&mut R> {
+    match self {
+      Right(r) => Some(r),
+      _ => None,
     }
   }
 
@@ -262,7 +434,7 @@ impl<L, M, R> Among<L, M, R> {
   /// let middle: Among<(), _, ()> = Middle(-321);
   /// assert_eq!(middle.as_ref(), Middle(&-321));
   /// ```
-  pub fn as_ref(&self) -> Among<&L, &M, &R> {
+  pub const fn as_ref(&self) -> Among<&L, &M, &R> {
     match *self {
       Left(ref inner) => Left(inner),
       Middle(ref inner) => Middle(inner),
@@ -292,7 +464,7 @@ impl<L, M, R> Among<L, M, R> {
   /// assert_eq!(right, Right(123));
   /// assert_eq!(middle, Middle(123));
   /// ```
-  pub fn as_mut(&mut self) -> Among<&mut L, &mut M, &mut R> {
+  pub const fn as_mut(&mut self) -> Among<&mut L, &mut M, &mut R> {
     match *self {
       Left(ref mut inner) => Left(inner),
       Middle(ref mut inner) => Middle(inner),
@@ -302,7 +474,7 @@ impl<L, M, R> Among<L, M, R> {
 
   /// Convert `Pin<&Among<L, M, R>>` to `Among<Pin<&L>, Pin<&M>, Pin<&R>>`,
   /// pinned projections of the inner variants.
-  pub fn as_pin_ref(self: Pin<&Self>) -> Among<Pin<&L>, Pin<&M>, Pin<&R>> {
+  pub const fn as_pin_ref(self: Pin<&Self>) -> Among<Pin<&L>, Pin<&M>, Pin<&R>> {
     // SAFETY: We can use `new_unchecked` because the `inner` parts are
     // guaranteed to be pinned, as they come from `self` which is pinned.
     unsafe {
@@ -316,7 +488,7 @@ impl<L, M, R> Among<L, M, R> {
 
   /// Convert `Pin<&mut Among<L, M, R>>` to `Among<Pin<&mut L>, Pin<&mut M>, Pin<&mut R>>`,
   /// pinned projections of the inner variants.
-  pub fn as_pin_mut(self: Pin<&mut Self>) -> Among<Pin<&mut L>, Pin<&mut M>, Pin<&mut R>> {
+  pub const fn as_pin_mut(self: Pin<&mut Self>) -> Among<Pin<&mut L>, Pin<&mut M>, Pin<&mut R>> {
     // SAFETY: `get_unchecked_mut` is fine because we don't move anything.
     // We can use `new_unchecked` because the `inner` parts are guaranteed
     // to be pinned, as they come from `self` which is pinned, and we never
@@ -470,6 +642,79 @@ impl<L, M, R> Among<L, M, R> {
       Middle(m) => Middle(m),
       Right(r) => Right(f(r)),
     }
+  }
+
+  /// Call `f` with the inner value if `self` is `Left`, then return `self` unchanged.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut seen = 0;
+  /// let left: Among<u32, u32, u32> = Left(5);
+  /// let left = left.inspect_left(|v| seen = *v);
+  /// assert_eq!(seen, 5);
+  /// assert_eq!(left, Left(5));
+  ///
+  /// // Other variants are passed through unobserved.
+  /// let right: Among<u32, u32, u32> = Right(9);
+  /// assert_eq!(right.inspect_left(|_| panic!("not called")), Right(9));
+  /// ```
+  pub fn inspect_left<F>(self, f: F) -> Self
+  where
+    F: FnOnce(&L),
+  {
+    if let Left(ref l) = self {
+      f(l);
+    }
+    self
+  }
+
+  /// Call `f` with the inner value if `self` is `Middle`, then return `self` unchanged.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut seen = 0;
+  /// let middle: Among<u32, u32, u32> = Middle(5);
+  /// let middle = middle.inspect_middle(|v| seen = *v);
+  /// assert_eq!(seen, 5);
+  /// assert_eq!(middle, Middle(5));
+  ///
+  /// let left: Among<u32, u32, u32> = Left(9);
+  /// assert_eq!(left.inspect_middle(|_| panic!("not called")), Left(9));
+  /// ```
+  pub fn inspect_middle<F>(self, f: F) -> Self
+  where
+    F: FnOnce(&M),
+  {
+    if let Middle(ref m) = self {
+      f(m);
+    }
+    self
+  }
+
+  /// Call `f` with the inner value if `self` is `Right`, then return `self` unchanged.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut seen = 0;
+  /// let right: Among<u32, u32, u32> = Right(5);
+  /// let right = right.inspect_right(|v| seen = *v);
+  /// assert_eq!(seen, 5);
+  /// assert_eq!(right, Right(5));
+  ///
+  /// let left: Among<u32, u32, u32> = Left(9);
+  /// assert_eq!(left.inspect_right(|_| panic!("not called")), Left(9));
+  /// ```
+  pub fn inspect_right<F>(self, f: F) -> Self
+  where
+    F: FnOnce(&R),
+  {
+    if let Right(ref r) = self {
+      f(r);
+    }
+    self
   }
 
   /// Apply the functions `f` and `g` to the `Left` and `Right` variants
@@ -782,8 +1027,7 @@ impl<L, M, R> Among<L, M, R> {
   /// assert_eq!(right.factor_into_iter().collect::<Vec<_>>(), vec![Right(0), Right(1)]);
   ///
   /// ```
-  // TODO(MSRV): doc(alias) was stabilized in Rust 1.48
-  // #[doc(alias = "transpose")]
+  #[doc(alias = "transpose")]
   pub fn factor_into_iter(self) -> IterAmong<L::IntoIter, M::IntoIter, R::IntoIter>
   where
     L: IntoIterator,
@@ -1209,7 +1453,10 @@ impl<L, M, R> Among<L, M, R> {
     match self {
       Among::Right(r) => r,
       Among::Middle(m) => {
-        panic!("called `Among::unwrap_right()` on a `Middle` value: {:?}", m)
+        panic!(
+          "called `Among::unwrap_right()` on a `Middle` value: {:?}",
+          m
+        )
       }
       Among::Left(l) => panic!("called `Among::unwrap_right()` on a `Left` value: {:?}", l),
     }
@@ -1382,6 +1629,186 @@ impl<L, M, R> Among<L, M, R> {
     }
   }
 
+  /// Replace `self` with `Left(value)` and return a mutable reference to the new value.
+  ///
+  /// Any previously-held `Middle` or `Right` value is dropped.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut a: Among<u32, u32, u32> = Right(1);
+  /// let l = a.insert_left(10);
+  /// *l += 1;
+  /// assert_eq!(a, Left(11));
+  /// ```
+  pub fn insert_left(&mut self, value: L) -> &mut L {
+    *self = Left(value);
+    match self {
+      Left(l) => l,
+      _ => unreachable!(),
+    }
+  }
+
+  /// Replace `self` with `Middle(value)` and return a mutable reference to the new value.
+  ///
+  /// Any previously-held `Left` or `Right` value is dropped.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut a: Among<u32, u32, u32> = Left(1);
+  /// let m = a.insert_middle(20);
+  /// *m += 1;
+  /// assert_eq!(a, Middle(21));
+  /// ```
+  pub fn insert_middle(&mut self, value: M) -> &mut M {
+    *self = Middle(value);
+    match self {
+      Middle(m) => m,
+      _ => unreachable!(),
+    }
+  }
+
+  /// Replace `self` with `Right(value)` and return a mutable reference to the new value.
+  ///
+  /// Any previously-held `Left` or `Middle` value is dropped.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut a: Among<u32, u32, u32> = Left(1);
+  /// let r = a.insert_right(30);
+  /// *r += 1;
+  /// assert_eq!(a, Right(31));
+  /// ```
+  pub fn insert_right(&mut self, value: R) -> &mut R {
+    *self = Right(value);
+    match self {
+      Right(r) => r,
+      _ => unreachable!(),
+    }
+  }
+
+  /// If `self` is `Left`, return a mutable reference to the contained value.
+  /// Otherwise replace `self` with `Left(default)` and return a mutable reference to it.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut keep: Among<u32, u32, u32> = Left(7);
+  /// assert_eq!(*keep.get_or_insert_left(99), 7);
+  ///
+  /// let mut overwrite: Among<u32, u32, u32> = Right(1);
+  /// assert_eq!(*overwrite.get_or_insert_left(99), 99);
+  /// assert_eq!(overwrite, Left(99));
+  /// ```
+  pub fn get_or_insert_left(&mut self, default: L) -> &mut L {
+    self.get_or_insert_left_with(|| default)
+  }
+
+  /// If `self` is `Middle`, return a mutable reference to the contained value.
+  /// Otherwise replace `self` with `Middle(default)` and return a mutable reference to it.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut keep: Among<u32, u32, u32> = Middle(7);
+  /// assert_eq!(*keep.get_or_insert_middle(99), 7);
+  ///
+  /// let mut overwrite: Among<u32, u32, u32> = Right(1);
+  /// assert_eq!(*overwrite.get_or_insert_middle(99), 99);
+  /// assert_eq!(overwrite, Middle(99));
+  /// ```
+  pub fn get_or_insert_middle(&mut self, default: M) -> &mut M {
+    self.get_or_insert_middle_with(|| default)
+  }
+
+  /// If `self` is `Right`, return a mutable reference to the contained value.
+  /// Otherwise replace `self` with `Right(default)` and return a mutable reference to it.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut keep: Among<u32, u32, u32> = Right(7);
+  /// assert_eq!(*keep.get_or_insert_right(99), 7);
+  ///
+  /// let mut overwrite: Among<u32, u32, u32> = Left(1);
+  /// assert_eq!(*overwrite.get_or_insert_right(99), 99);
+  /// assert_eq!(overwrite, Right(99));
+  /// ```
+  pub fn get_or_insert_right(&mut self, default: R) -> &mut R {
+    self.get_or_insert_right_with(|| default)
+  }
+
+  /// Like [`get_or_insert_left`][Self::get_or_insert_left] but computes the default lazily.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut a: Among<u32, u32, u32> = Right(1);
+  /// let l = a.get_or_insert_left_with(|| 42);
+  /// *l += 1;
+  /// assert_eq!(a, Left(43));
+  /// ```
+  pub fn get_or_insert_left_with<F>(&mut self, f: F) -> &mut L
+  where
+    F: FnOnce() -> L,
+  {
+    if !self.is_left() {
+      *self = Left(f());
+    }
+    match self {
+      Left(l) => l,
+      _ => unreachable!(),
+    }
+  }
+
+  /// Like [`get_or_insert_middle`][Self::get_or_insert_middle] but computes the default lazily.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut a: Among<u32, u32, u32> = Right(1);
+  /// let m = a.get_or_insert_middle_with(|| 42);
+  /// *m += 1;
+  /// assert_eq!(a, Middle(43));
+  /// ```
+  pub fn get_or_insert_middle_with<F>(&mut self, f: F) -> &mut M
+  where
+    F: FnOnce() -> M,
+  {
+    if !self.is_middle() {
+      *self = Middle(f());
+    }
+    match self {
+      Middle(m) => m,
+      _ => unreachable!(),
+    }
+  }
+
+  /// Like [`get_or_insert_right`][Self::get_or_insert_right] but computes the default lazily.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut a: Among<u32, u32, u32> = Left(1);
+  /// let r = a.get_or_insert_right_with(|| 42);
+  /// *r += 1;
+  /// assert_eq!(a, Right(43));
+  /// ```
+  pub fn get_or_insert_right_with<F>(&mut self, f: F) -> &mut R
+  where
+    F: FnOnce() -> R,
+  {
+    if !self.is_right() {
+      *self = Right(f());
+    }
+    match self {
+      Right(r) => r,
+      _ => unreachable!(),
+    }
+  }
+
   /// Convert the contained value into `T`
   ///
   /// ## Examples
@@ -1406,6 +1833,37 @@ impl<L, M, R> Among<L, M, R> {
       Among::Left(l) => l.into(),
       Among::Middle(m) => m.into(),
       Among::Right(r) => r.into(),
+    }
+  }
+
+  /// Attempt to convert the contained value into `T`, wrapping any conversion error
+  /// in an `Among` preserving the originating side.
+  ///
+  /// ## Examples
+  ///
+  /// ```
+  /// # use among::*;
+  /// // i64 -> i32 is fallible. Picking values that fit succeeds.
+  /// let left: Among<i64, i32, u32> = Left(3i64);
+  /// assert_eq!(left.try_among_into::<i32>().ok(), Some(3i32));
+  ///
+  /// // A value that doesn't fit comes back as an Among carrying the source-side error.
+  /// let left: Among<i64, i32, u32> = Left(i64::MAX);
+  /// assert!(matches!(left.try_among_into::<i32>(), Err(Left(_))));
+  /// ```
+  #[allow(clippy::type_complexity)]
+  pub fn try_among_into<T>(
+    self,
+  ) -> Result<T, Among<<L as TryInto<T>>::Error, <M as TryInto<T>>::Error, <R as TryInto<T>>::Error>>
+  where
+    L: TryInto<T>,
+    M: TryInto<T>,
+    R: TryInto<T>,
+  {
+    match self {
+      Among::Left(l) => l.try_into().map_err(Among::Left),
+      Among::Middle(m) => m.try_into().map_err(Among::Middle),
+      Among::Right(r) => r.try_into().map_err(Among::Right),
     }
   }
 }
@@ -1558,6 +2016,40 @@ impl<T> Among<T, T, T> {
     for_all!(self, inner => inner)
   }
 
+  /// Borrow the contained value when all three type parameters match.
+  ///
+  /// Unlike [`into_inner`][Self::into_inner], this does not consume `self`.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let left: Among<i32, i32, i32> = Left(1);
+  /// let middle: Among<i32, i32, i32> = Middle(2);
+  /// let right: Among<i32, i32, i32> = Right(3);
+  ///
+  /// assert_eq!(*left.as_inner(), 1);
+  /// assert_eq!(*middle.as_inner(), 2);
+  /// assert_eq!(*right.as_inner(), 3);
+  /// ```
+  pub const fn as_inner(&self) -> &T {
+    for_all!(*self, ref inner => inner)
+  }
+
+  /// Mutably borrow the contained value when all three type parameters match.
+  ///
+  /// Unlike [`into_inner`][Self::into_inner], this does not consume `self`.
+  ///
+  /// ```
+  /// use among::*;
+  ///
+  /// let mut value: Among<i32, i32, i32> = Middle(0);
+  /// *value.as_inner_mut() = 42;
+  /// assert_eq!(value, Middle(42));
+  /// ```
+  pub const fn as_inner_mut(&mut self) -> &mut T {
+    for_all!(*self, ref mut inner => inner)
+  }
+
   /// Map `f` over the contained value and return the result in the
   /// corresponding variant.
   ///
@@ -1599,7 +2091,7 @@ impl<L, M, R> Among<&L, &M, &R> {
 
   /// Maps an `Among<&L, &M, &R>` to an `Among<L, M, R>` by copying the contents of
   /// among branch.
-  pub fn copied(self) -> Among<L, M, R>
+  pub const fn copied(self) -> Among<L, M, R>
   where
     L: Copy,
     M: Copy,
@@ -1631,7 +2123,7 @@ impl<L, M, R> Among<&mut L, &mut M, &mut R> {
 
   /// Maps an `Among<&mut L, &mut M, &mut R>` to an `Among<L, M, R>` by copying the contents of
   /// among branch.
-  pub fn copied(self) -> Among<L, M, R>
+  pub const fn copied(self) -> Among<L, M, R>
   where
     L: Copy,
     M: Copy,

--- a/src/serde_untagged.rs
+++ b/src/serde_untagged.rs
@@ -15,7 +15,7 @@
 //! struct IntOrString {
 //!     #[serde(with = "among::serde_untagged")]
 //!     inner: Among<Vec<String>, Box<str>, HashMap<String, i32>>
-//! };
+//! }
 //!
 //! // serialization
 //! let data = IntOrString {

--- a/src/serde_untagged_optional.rs
+++ b/src/serde_untagged_optional.rs
@@ -15,7 +15,7 @@
 //! struct IntOrString {
 //!     #[serde(with = "among::serde_untagged_optional")]
 //!     inner: Option<Among<Vec<String>, Box<str>, HashMap<String, i32>>>
-//! };
+//! }
 //!
 //! // serialization
 //! let data = IntOrString {


### PR DESCRIPTION
## Summary

Prepares the `0.2.0` release. Headline changes:

- Raises the MSRV to **1.85.0** so that the borrowing accessors can become `const fn`.
- Makes 17 borrowing / `Copy`-bounded methods `const fn`.
- Adds 24 new combinators inspired by `Option` / `Result` / `Either` idioms.
- Fixes several panic-message and documentation bugs.

Everything is described in more detail in `CHANGELOG.md`.

## Breaking

- **MSRV bumped to 1.85.0.** All other public API is backward-compatible at source and binary level.

## Features

### New `const fn` methods
Existing borrowing methods are now usable in `const` contexts:

- `is_left`, `is_middle`, `is_right`
- `as_ref`, `as_mut`, `as_pin_ref`, `as_pin_mut`
- `left_ref`, `middle_ref`, `right_ref`, `left_mut`, `middle_mut`, `right_mut`
- `Among::<T, T, T>::as_inner`, `Among::<T, T, T>::as_inner_mut`
- `Among::<&L, &M, &R>::copied`, `Among::<&mut L, &mut M, &mut R>::copied`

### New combinators
- Predicate checks: `is_left_and`, `is_middle_and`, `is_right_and`
- Side-effect observers: `inspect_left`, `inspect_middle`, `inspect_right`
- `Option<&_>` / `Option<&mut _>` shortcuts: `left_ref`, `middle_ref`, `right_ref`, `left_mut`, `middle_mut`, `right_mut`
- Variant setters: `insert_left`, `insert_middle`, `insert_right`
- Keep-or-insert setters (eager + lazy): `get_or_insert_{left,middle,right}` and `get_or_insert_{left,middle,right}_with`
- Fallible conversion: `try_among_into::<T>` → `Result<T, Among<E_L, E_M, E_R>>`
- Borrowing companions on `Among<T, T, T>`: `as_inner`, `as_inner_mut`

## Bug fixes

- `Among::unwrap_left` panic message now references `unwrap_left` (was `unwrap_middle`) when invoked on a `Middle` value.
- `Among::unwrap_right` panic message now references `unwrap_right` (was `unwrap_middle`) when invoked on a `Middle` value.
- `Clone::clone_from` gains the missing `(Middle, Middle)` in-place branch so the `Middle` variant reuses its allocation like `Left` / `Right`.

## Docs

- Fix `Among::is_middle` rustdoc headline that described the `Right` variant.
- Expand the `# Panics` sections on `unwrap_left`, `unwrap_middle`, `unwrap_right` to list both panicking variants.
- Add `# Panics` sections to `Among::into_left_middle`, `Among::into_middle_right`, `Among::into_left_right`.
- Drop stray `};` after the `struct` blocks in the `serde_untagged` / `serde_untagged_optional` module-level doctests.

## Tests

- Remove the unused `mockvec` write inside the `seek` test's mock-data loop.

## Test plan

- [x] `cargo check --all-features`
- [x] `cargo test --all-features` (7 unit tests + 102 doctests pass)
- [x] `cargo clippy --all-features --lib --tests -- -D warnings`